### PR TITLE
Various fixes and improvements

### DIFF
--- a/sender_policy_flattener/__init__.py
+++ b/sender_policy_flattener/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import json
 from dns.resolver import Resolver
-from sender_policy_flattener.crawler import spf2ips, crawl
+from sender_policy_flattener.crawler import spf2ips
 from sender_policy_flattener.formatting import sequence_hash
 from sender_policy_flattener.email_utils import email_changes
 

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -28,6 +28,8 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
         answer = ' '.join([str(a) for a in answers])
         for pair in tokenize(answer):
             rname, rtype = pair
+            if rtype is None:
+                continue
             if rtype == 'txt':
                 for ip in crawl(rname, 'txt', domain, ns):
                     yield ip

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -2,6 +2,7 @@
 
 from dns import resolver  # dnspython/3
 from dns.resolver import NXDOMAIN
+from dns.name import from_text
 from sender_policy_flattener.formatting import wrap_in_spf_tokens, ips_to_spf_strings, fit_bytes
 from sender_policy_flattener.mechanisms import tokenize
 from sender_policy_flattener.handlers import handler_mapping
@@ -21,7 +22,7 @@ def spf2ips(records, domain, resolvers=default_resolvers):
 
 def crawl(rrname, rrtype, domain, ns=default_resolvers):
     try:
-        answers = ns.query(rrname, rrtype)
+        answers = ns.query(from_text(rrname), rrtype)
     except Exception as err:
         print(repr(err), rrname, rrtype)
     else:

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from dns import resolver  # dnspython/3
+from dns.resolver import NXDOMAIN
 from sender_policy_flattener.formatting import wrap_in_spf_tokens, ips_to_spf_strings, fit_bytes
 from sender_policy_flattener.mechanisms import tokenize
 from sender_policy_flattener.handlers import handler_mapping
@@ -31,5 +32,8 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
                 for ip in crawl(rname, 'txt', domain, ns):
                     yield ip
                 continue
-            for ip in handler_mapping[rtype](rname, domain, ns):
-                yield ip
+            try:
+                for ip in handler_mapping[rtype](rname, domain, ns):
+                    yield ip
+            except NXDOMAIN as e:
+                print(e)

--- a/sender_policy_flattener/formatting.py
+++ b/sender_policy_flattener/formatting.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import hashlib
 import sys
-from netaddr import IPSet, IPAddress, IPNetwork, AddrFormatError
+from netaddr import IPSet, IPNetwork, AddrFormatError
 
 
 def wrap_in_spf_tokens(domain, ipv4blocks, last_record):

--- a/sender_policy_flattener/handlers.py
+++ b/sender_policy_flattener/handlers.py
@@ -9,9 +9,9 @@ def handle_ip(name, domain, ns):
 def handle_mx(name, domain, ns):
     answers = ns.query(domain, 'mx')
     for mailexchange in answers:
-        ips = ns.query(mailexchange, 'a')
+        ips = ns.query(mailexchange.exchange, 'a')
         for ip in ips:
-            yield IPAddress(ip)
+            yield IPAddress(ip.address)
 
 
 def handle_mx_domain(name, domain, ns):
@@ -19,7 +19,7 @@ def handle_mx_domain(name, domain, ns):
     for mailexchange in answers:
         ips = ns.query(mailexchange, 'a')
         for ip in ips:
-            yield IPAddress(ip)
+            yield IPAddress(ip.address)
 
 
 def handle_mx_prefix(name, domain, ns):
@@ -43,13 +43,13 @@ def handle_mx_domain_prefix(name, domain, ns):
 def handle_a(name, domain, ns):
     answers = ns.query(domain, 'a')
     for ip in answers:
-        yield IPAddress(ip)
+        yield IPAddress(ip.address)
 
 
 def handle_a_domain(name, domain, ns):
     answers = ns.query(name, 'a')
     for ip in answers:
-        yield IPAddress(ip)
+        yield IPAddress(ip.address)
 
 
 def handle_a_prefix(name, domain, ns):

--- a/sender_policy_flattener/handlers.py
+++ b/sender_policy_flattener/handlers.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from netaddr import IPNetwork, IPAddress
+from dns.name import from_text
 
 
 def handle_ip(name, domain, ns):
@@ -7,7 +8,7 @@ def handle_ip(name, domain, ns):
 
 
 def handle_mx(name, domain, ns):
-    answers = ns.query(domain, 'mx')
+    answers = ns.query(from_text(domain), 'mx')
     for mailexchange in answers:
         ips = ns.query(mailexchange.exchange, 'a')
         for ip in ips:
@@ -15,7 +16,7 @@ def handle_mx(name, domain, ns):
 
 
 def handle_mx_domain(name, domain, ns):
-    answers = ns.query(name, 'mx')
+    answers = ns.query(from_text(name), 'mx')
     for mailexchange in answers:
         ips = ns.query(mailexchange, 'a')
         for ip in ips:
@@ -24,16 +25,16 @@ def handle_mx_domain(name, domain, ns):
 
 def handle_mx_prefix(name, domain, ns):
     _name, prefix = name
-    answers = ns.query(domain, 'mx')
+    answers = ns.query(from_text(domain), 'mx')
     for mailexchange in answers:
-        ips = ns.query(mailexchange, 'a')
+        ips = ns.query(mailexchange.exchange, 'a')
         for ip in ips:
             yield IPNetwork('{0}/{1}'.format(ip, prefix))
 
 
 def handle_mx_domain_prefix(name, domain, ns):
     _name, prefix = name
-    answers = ns.query(_name, 'mx')
+    answers = ns.query(from_text(_name), 'mx')
     for mailexchange in answers:
         ips = ns.query(mailexchange, 'a')
         for ip in ips:
@@ -41,27 +42,27 @@ def handle_mx_domain_prefix(name, domain, ns):
 
 
 def handle_a(name, domain, ns):
-    answers = ns.query(domain, 'a')
+    answers = ns.query(from_text(domain), 'a')
     for ip in answers:
         yield IPAddress(ip.address)
 
 
 def handle_a_domain(name, domain, ns):
-    answers = ns.query(name, 'a')
+    answers = ns.query(from_text(name), 'a')
     for ip in answers:
         yield IPAddress(ip.address)
 
 
 def handle_a_prefix(name, domain, ns):
     _name, prefix = name
-    answers = ns.query(domain, 'a')
+    answers = ns.query(from_text(domain), 'a')
     for ip in answers:
         yield IPNetwork('{0}/{1}'.format(ip, prefix))
 
 
 def handle_a_domain_prefix(name, domain, ns):
     _name, prefix = name
-    answers = ns.query(_name, 'a')
+    answers = ns.query(from_text(_name), 'a')
     for ip in answers:
         yield IPNetwork('{0}/{1}'.format(ip, prefix))
 


### PR DESCRIPTION
I tried running this with Python 3.8 and got various problems with return types from `query()` not being what the code expects.

Also, I needed this to be more resilient on bad input, namely TXT records that aren't SPF records (previously this failed non-deterministically with an exception) and includes that yield NXDOMAIN (you could argue that this shouldn't simply be printed, but somehow communicated differently, but I'm not using the whole sciprt, only the `crawl()` function, so this was appropriate for me)