### PR TITLE
Add from header

### DIFF
--- a/sender_policy_flattener/email_utils.py
+++ b/sender_policy_flattener/email_utils.py
@@ -49,6 +49,7 @@ def email_changes(
     html = MIMEText(html, "html")
     msg_template = MIMEMultipart("alternative")
     msg_template["Subject"] = subject.format(zone=zone)
+    msg_template["From"] = fromaddr
     email = msg_template
     email.attach(html)
 


### PR DESCRIPTION
Some email servers require a from header (https://github.com/postalserver/postal/issues/2088) so add the sender's address as the `from` header