### PR TITLE
rework TXT record handling and tokenization

### DIFF
--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -26,21 +26,15 @@ def spf2ips(records, domain, resolvers=default_resolvers):
 
 def crawl(rrname, rrtype, domain, ns=default_resolvers):
     try:
-        answers = ns.query(from_text(rrname), rrtype)
+        answers = ns.resolve(from_text(rrname), rrtype)
     except Exception as err:
         print(repr(err), rrname, rrtype)
     else:
         for answer in answers:
             for pair in tokenize(str(answer), rrtype):
                 rname, rtype = pair
-                if rtype is None:
-                    continue
-                if rtype == "txt":
-                    for ip in crawl(rname, rtype, domain, ns):
-                        yield ip
-                    continue
-                try:
-                    for ip in handler_mapping[rtype](rname, domain, ns):
-                        yield ip
-                except (NXDOMAIN, NoAnswer) as e:
-                    print(e)
+                if rtype is not None:
+                    try:
+                        yield from handler_mapping[rtype](rname, domain, ns):
+                    except (NXDOMAIN, NoAnswer) as e:
+                        print(e)

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -30,17 +30,17 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
     except Exception as err:
         print(repr(err), rrname, rrtype)
     else:
-        answer = " ".join([str(a) for a in answers])
-        for pair in tokenize(answer):
-            rname, rtype = pair
-            if rtype is None:
-                continue
-            if rtype == "txt":
-                for ip in crawl(rname, "txt", domain, ns):
-                    yield ip
-                continue
-            try:
-                for ip in handler_mapping[rtype](rname, domain, ns):
-                    yield ip
-            except (NXDOMAIN, NoAnswer) as e:
-                print(e)
+        for answer in answers:
+            for pair in tokenize(str(answer), rrtype):
+                rname, rtype = pair
+                if rtype is None:
+                    continue
+                if rtype == "txt":
+                    for ip in crawl(rname, rtype, domain, ns):
+                        yield ip
+                    continue
+                try:
+                    for ip in handler_mapping[rtype](rname, domain, ns):
+                        yield ip
+                except (NXDOMAIN, NoAnswer) as e:
+                    print(e)

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -35,6 +35,6 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
                 rname, rtype = pair
                 if rtype is not None:
                     try:
-                        yield from handler_mapping[rtype](rname, domain, ns):
+                        yield from handler_mapping[rtype](rname, domain, ns)
                     except (NXDOMAIN, NoAnswer) as e:
                         print(e)

--- a/sender_policy_flattener/handlers.py
+++ b/sender_policy_flattener/handlers.py
@@ -2,77 +2,83 @@
 from netaddr import IPNetwork, IPAddress
 from dns.name import from_text
 
+import sender_policy_flattener.crawler as crawler
+
 
 def handle_ip(name, domain, ns):
     yield name
 
 
-def handle_mx(name, domain, ns):
-    answers = ns.query(from_text(domain), "mx")
+def handle_mx(_, domain, ns):
+    answers = ns.resolve(from_text(domain), "mx")
     for mailexchange in answers:
-        ips = ns.query(mailexchange.exchange, "a")
+        ips = ns.resolve(mailexchange.exchange, "a")
         for ip in ips:
             yield IPAddress(ip.address)
 
 
-def handle_mx_domain(name, domain, ns):
-    answers = ns.query(from_text(name), "mx")
+def handle_mx_domain(name, __, ns):
+    answers = ns.resolve(from_text(name), "mx")
     for mailexchange in answers:
-        ips = ns.query(mailexchange, "a")
+        ips = ns.resolve(mailexchange, "a")
         for ip in ips:
             yield IPAddress(ip.address)
 
 
 def handle_mx_prefix(name, domain, ns):
-    _name, prefix = name
-    answers = ns.query(from_text(domain), "mx")
+    _, prefix = name
+    answers = ns.resolve(from_text(domain), "mx")
     for mailexchange in answers:
-        ips = ns.query(mailexchange.exchange, "a")
+        ips = ns.resolve(mailexchange.exchange, "a")
         for ip in ips:
             yield IPNetwork("{0}/{1}".format(ip, prefix))
 
 
-def handle_mx_domain_prefix(name, domain, ns):
-    _name, prefix = name
-    answers = ns.query(from_text(_name), "mx")
+def handle_mx_domain_prefix(name, __, ns):
+    _, prefix = name
+    answers = ns.resolve(from_text(_name), "mx")
     for mailexchange in answers:
-        ips = ns.query(mailexchange, "a")
+        ips = ns.resolve(mailexchange, "a")
         for ip in ips:
             yield IPNetwork("{0}/{1}".format(ip, prefix))
 
 
-def handle_a(name, domain, ns):
-    answers = ns.query(from_text(domain), "a")
+def handle_a(_, domain, ns):
+    answers = ns.resolve(from_text(domain), "a")
     for ip in answers:
         yield IPAddress(ip.address)
 
 
-def handle_a_domain(name, domain, ns):
-    answers = ns.query(from_text(name), "a")
+def handle_a_domain(name, __, ns):
+    answers = ns.resolve(from_text(name), "a")
     for ip in answers:
         yield IPAddress(ip.address)
 
 
 def handle_a_prefix(name, domain, ns):
-    _name, prefix = name
-    answers = ns.query(from_text(domain), "a")
+    _, prefix = name
+    answers = ns.resolve(from_text(domain), "a")
     for ip in answers:
         yield IPNetwork("{0}/{1}".format(ip, prefix))
 
 
-def handle_a_domain_prefix(name, domain, ns):
-    _name, prefix = name
-    answers = ns.query(from_text(_name), "a")
+def handle_a_domain_prefix(name, __, ns):
+    _, prefix = name
+    answers = ns.resolve(from_text(_name), "a")
     for ip in answers:
         yield IPNetwork("{0}/{1}".format(ip, prefix))
 
 
-def handle_ptr(name, domain, ns):
+def handle_ptr(name, __, ___):
     yield "ptr:{0}".format(name)
 
 
-def handle_exists(name, domain, ns):
+def handle_exists(name, __, ___):
     yield "exists:{0}".format(name)
+
+
+def handle_txt(name, domain, ns):
+    yield from crawler.crawl(name, "txt", domain, ns)
 
 
 handler_mapping = {
@@ -87,4 +93,5 @@ handler_mapping = {
     "a_domain_prefix": handle_a_domain_prefix,
     "ptr": handle_ptr,
     "exists": handle_exists,
+    "txt": handle_txt
 }


### PR DESCRIPTION
Currently the crawler does not handle TXT records properly, breaking SPF record entries in cases where the TXT record is split in several parts (e.g. `0.spf0.hubspotemail.net`). The crawler currently also handles other TXT records even if they don't start with `v=spf1` which is against the specification.

This PR superseeds #19 as we currently use the modified version in production. This modified version also introduces some code cleanups suggested by @tresni in [his fork](https://github.com/tresni/sender_policy_flattener). Our modified version might introduce additional improvements in the future.